### PR TITLE
[이예솔] Add: users app >> test.py kakaoLoginTest

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,7 @@
 Django==4.0.3
 django-cors-headers==3.11.0
 mysqlclient==2.1.0
+boto3==1.21.19
+django-storages==1.12.3
+PyJWT==2.3.0
+requests==2.27.1

--- a/users/tests.py
+++ b/users/tests.py
@@ -1,3 +1,156 @@
-from django.test import TestCase
+import jwt
 
-# Create your tests here.
+from django.test    import Client, TestCase
+from unittest.mock  import MagicMock, patch
+
+from datetime       import datetime, timedelta
+from my_settings    import SECRET_KEY, ALGORITHM
+from users.models   import User
+
+class KakaoLoginTest(TestCase):
+    @classmethod
+    def setUpTestData(self):
+        User.objects.create(
+            id                = 1,
+            kakao_nickname    = "핑핑이",
+            kakao_email       = "pingping@gmail.com",
+            kakao_id          = 1234567,
+            profile_image_url = "http://111.jpg"
+        )
+
+    def tearDown(self):
+        User.objects.all().delete()
+
+    @patch("users.views.requests")
+    def test_login_success_for_user(self, mocked_requests):
+        client = Client()
+
+        class MockedResponse:
+            def json(self):
+                return {
+                    "id":1234567,
+                    "properties":{
+                        "profile_image":"http://111.jpg",
+                        "nickname"     :"핑핑이"
+                    },
+                    "kakao_account":{
+                        "email":"pingping@gmail.com"
+                    }
+                }
+        mocked_requests.get = MagicMock(return_value = MockedResponse())
+
+        headers  = {"HTTP_access_token":"fakeTokenforTest"}
+        response = client.get("/users/kakao/login", **headers)
+
+        response_token = response.json()["results"]["token"]
+        payload        = jwt.decode(response_token, SECRET_KEY, ALGORITHM)  
+        token          = jwt.encode({"id":payload["id"], "exp":datetime.utcnow() + timedelta(days=2)}, SECRET_KEY, ALGORITHM)
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.json(), {
+            "results":{
+                "token"            :token,
+                "kakao_email"      :"pingping@gmail.com",
+                "kakao_nickname"   :"핑핑이",
+                "profile_image_url":"http://111.jpg"
+            }
+        })
+
+    @patch("users.views.requests")
+    def test_fail_for_absence_of_kakao_token(self, mocked_requests):
+        client = Client()
+
+        class MockedResponse:
+            def json(self):
+                return {
+                    "id":1234567,
+                    "properties":{
+                        "profile_image":"http://111.jpg",
+                        "nickname"     :"핑핑이"
+                    },
+                    "kakao_account":{
+                        "email":"pingping@gmail.com"
+                    }
+                }
+        mocked_requests.get = MagicMock(return_value = MockedResponse())
+
+        response = client.get("/users/kakao/login")
+
+        self.assertEqual(response.status_code, 401)
+        self.assertEqual(response.json(), {"message":"Invalid Access Token"})
+
+    @patch("users.views.requests")
+    def test_login_fail_for_invalid_user_information_from_kakao(self, mocked_requests):
+        client = Client()
+
+        class MockedResponse:
+            def json(self):
+                return {
+                    "properties":{
+                        "profile_image":"http://111.jpg"
+                    }
+                }
+        mocked_requests.get = MagicMock(return_value = MockedResponse())
+        
+        headers  = {"HTTP_access_token":"fakeTokenforTest"}
+        response = client.get("/users/kakao/login", **headers)
+
+        self.assertEqual(response.status_code, 400)
+        self.assertEqual(response.json(), {"message":"Key Error"})
+
+    @patch("users.views.requests")
+    def test_login_fail_for_time_out(self, mocked_requests):
+        client = Client()
+
+        class MockedResponse:
+            def json(self):
+                return {
+                    "id":1234567,
+                    "properties":{
+                        "profile_image":"http://111.jpg",
+                        "nickname"     :"핑핑이"
+                    },
+                    "kakao_account":{
+                        "email":"pingping@gmail.com"
+                    }
+                }
+        mocked_requests.get = MagicMock(return_value = MockedResponse())
+        
+        headers  = {"HTTP_access_token":"fakeTokenforTest"}
+        response = client.get("/users/kakao/login", **headers)
+
+        self.assertEqual(response.status_code, 400)
+        self.assertEqual(response.json(), {"message":"Time Out"})
+
+    @patch("users.views.requests")
+    def test_update_success_for_existing_user(self, mocked_requests):
+        client = Client()
+
+        class MockedResponse:
+            def json(self):
+                return {
+                    "id":1234567,
+                    "properties":{
+                        "profile_image":"http://1313.jpg",
+                        "nickname"     :"세젤귀 핑핑"
+                    },
+                    "kakao_account":{
+                        "email":"pingping@gmail.com"
+                    }
+                }
+        mocked_requests.get = MagicMock(return_value = MockedResponse())
+
+        headers  = {"HTTP_access_token":"fakeTokenforTest"}
+        response = client.get("/users/kakao/login", **headers)
+
+        response_token = response.json()["results"]["token"]
+        payload        = jwt.decode(response_token, SECRET_KEY, ALGORITHM)  
+        token          = jwt.encode({"id":payload["id"], "exp":datetime.utcnow() + timedelta(days=2)}, SECRET_KEY, ALGORITHM)
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.json(), {
+            "results":{
+                "token"            :token,
+                "kakao_email"      :"pingping@gmail.com",
+                "kakao_nickname"   :"세젤귀 핑핑",
+                "profile_image_url":"http://1313.jpg"
+            }
+        })

--- a/users/views.py
+++ b/users/views.py
@@ -1,8 +1,9 @@
 import requests, jwt
 
-from datetime         import datetime, timedelta
-from django.http      import JsonResponse
-from django.views     import View
+from datetime               import datetime, timedelta
+from django.http            import JsonResponse
+from django.views           import View
+from requests.exceptions    import Timeout
 
 from my_settings      import SECRET_KEY, ALGORITHM
 from users.models     import User
@@ -10,33 +11,35 @@ from users.models     import User
 class KakaoLoginView(View):
     def get(self, request):
         try:
-            access_token = request.headers.get("access_token", None)
+            access_token = request.headers.get("Authorization", None)
 
             if access_token == None:
                 return JsonResponse({"message":"Invalid Access Token"}, status=401)
 
             kakao_user_api   = "https://kapi.kakao.com/v2/user/me"
             headers          = {"Authorization":f"Bearer ${access_token}"}
-            user_information = requests.get(kakao_user_api, headers=headers, timeout=6).json()
+            user_information = requests.get(kakao_user_api, headers=headers, timeout=5).json()
 
             kakao_id          = user_information["id"]
+            kakao_email       = user_information["kakao_account"]["email"]
             profile_image_url = user_information["properties"]["profile_image"]
             kakao_nickname    = user_information["properties"]["nickname"]
 
             user, created = User.objects.update_or_create( 
                 kakao_id = kakao_id, 
-                defaults = {"kakao_nickname":kakao_nickname, "profile_image_url":profile_image_url}
+                defaults = {"kakao_nickname":kakao_nickname, "profile_image_url":profile_image_url, "kakao_email":kakao_email}
             )
 
             token = jwt.encode({"id":user.id, "exp":datetime.utcnow() + timedelta(days=2)}, SECRET_KEY, ALGORITHM)
 
             results = {
                 "token"            :token,
+                "kakao_email"      :user.kakao_email,
                 "kakao_nickname"   :user.kakao_nickname,
                 "profile_image_url":user.profile_image_url
             }
             return JsonResponse({"results":results}, status=200)
-        except requests.exceptions.Timeout:
+        except Timeout:
             return JsonResponse({"message":"Time Out"}, status=408)
         except KeyError:
             return JsonResponse({"message":"Key Error"}, status=400)


### PR DESCRIPTION
## :: 최근 작업 주제 (하나 이상의 주제를 선택해주세요.)
- [x] 기능 추가
- [ ] 리뷰 반영
- [ ] 리팩토링
- [ ] 버그 수정
- [ ] 컨벤션 수정

<br />

## :: 구현 목표 (해당 브랜치에서 구현하고자 하는 하나의 목표를 설정합니다.)
- 카카오 소셜 로그인 기능 테스트

<br />

## :: 구현 사항 설명 (작업한 내용을 상세하게 기록합니다.)
1. users.view.py 수정
- KakaoLoginView에 있는 Timeout exception이 수정되었습니다. 기존의 exception이 처리되지 않고 에러가 발생해 살펴보니 이제껏 Timeoout 에러가 발생하지 않아 몰랐는데, import하는 방식이 잘못되어 있었습니다.  `from requests.exceptions    import Timeout`을 사용해 수정을 마쳤습니다.

2. users.tests.py 생성
- def test_login_success_for_user : 성공
- def test_fail_for_absence_of_kakao_token : 프론트로부터 헤더에 카카오 토큰()이 전달되지 않았을 경우 실패
- def test_login_fail_for_key_error : 카카오로부터 충분한 정보가 전달되지 않았을 경우 실파
- def test_login_fail_for_time_out : Timeout 에러. time을 import해 time.sleep(10)를 view에 삽입했을 경우 실패 (기존 requests.get()에서 timeout을 0이나 0.05, 심지어 음수로 수정해도 에러가 발생하지 않아서 사용했습니다.)

 3. requirements.txt 수정
- 로그인 및 로그인 데코레이터에 필요한 모듈들 추가

<br />

## :: 성장 포인트 (해당 기능을 구현하며 고민했던 사항이나 새로 알게된 부분, 어려웠던 점 등을 작성합니다.)
- timeout을 제대로 except하는 방법을 찾는 것이 어려웠습니다. 특히 requests만 import하는게 아니라 exception을 따로 import해야 한다는 것이 새로웠습니다.

<br />

## :: 기타 질문 및 특이 사항
- 테스트 케이스에 반복되는 부분이 많은데, 이런 부분을 함수에 저장해 사용하는 것은 어떤지 궁금합니다.