### PR TITLE
[이예솔] 채용 공고 리스트, 상세 정보 api + 공고에 대한 유저 정보 api

### DIFF
--- a/jobs/tests.py
+++ b/jobs/tests.py
@@ -1,3 +1,199 @@
-from django.test import TestCase
+import jwt
 
-# Create your tests here.
+from datetime       import datetime, timedelta
+from django.test    import Client, TestCase
+
+from django.utils   import dateparse, timezone
+from unittest       import mock
+
+from my_settings            import SECRET_KEY, ALGORITHM
+from applications.models    import Application, Applicant, ApplicationStatus
+from cv.models              import Resume
+from jobs.models            import JobPosition, JobCategory, Company, CompanyImage, Tag, TagNotification
+from users.models           import User
+
+class JobPositionTest(TestCase):
+    @classmethod
+    def setUpTestData(self):    
+        User.objects.create(
+            id                = 1,
+            kakao_nickname    = "핑핑이",
+            kakao_email       = "pingping@gmail.com",
+            kakao_id          = 123456789,
+            profile_image_url = "http://111.jpg"
+        )
+        Applicant.objects.create(
+            id      = 1,
+            user_id = 1
+        )
+        Resume.objects.create(
+            id         = 1,
+            name       = "이력서최종",
+            file_url   = "https://www.robertwalters.co.kr/content/dam/robert-walters/country/korea/files/resume/RESUME_Templete_1_KR.jpg",
+            uuid       = "8b34d6f8-4a0f-4e77-9b50-22d562708fe5",
+            is_deleted = False,
+            user_id    = 1
+        )
+        JobCategory.objects.create(
+            id   = 1,
+            name = "Web Backend"
+        )
+        Company.objects.create(
+            id             = 1,
+            name           = "테슬라",
+            location       = "미국 텍사스",
+            average_salary = 13500
+        )
+        CompanyImage.objects.create(
+            id         = 1,
+            company_id = 1,
+            image_url  = "https://raw.githubusercontent.com/wingna1/wantuPicbase/main/tesla1.jpg"
+        )
+        Tag.objects.create(
+            id   = 1,
+            name = "#자율복장"
+        )
+        JobPosition.objects.create(
+            id              = 1,
+            title           = "개발자 구합니다",
+            content         = "4대보험 가능! 근로계약서 작성 노동청 앞에서 함!",
+            due_date        = "2022-04-02",
+            company_id      = 1,
+            job_category_id = 1
+        )
+        JobPosition.objects.create(
+            id              = 2,
+            title           = "개발자 환영! 대환영!",
+            content         = "세상에 없던 서비스 등장! 함께하실 개발자를 구합니다",
+            due_date        = "2022-04-06",
+            company_id      = 1,
+            job_category_id = 1
+        )
+        TagNotification.objects.create(
+            id              = 1,
+            tag_id          = 1,
+            job_position_id = 1
+        )
+        ApplicationStatus.objects.create(
+            id     = 1,
+            status = "applied"
+        )
+        Application.objects.create(
+            id              = 1,
+            applicant_id    = 1,
+            resume_id       = 1,
+            job_position_id = 1,
+            status_id       = 1,
+        )
+
+    def tearDown(self):
+        JobPosition.objects.all().delete()
+
+    def test_success_for_getting_user_data_about_job_position(self):
+        client   = Client()
+        token    = jwt.encode({"id":1, "exp":datetime.utcnow() + timedelta(days=2)}, SECRET_KEY, ALGORITHM)
+        headers  = {"HTTP_Authorization":token}
+        response = client.get("/jobs/1/user", **headers)
+
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.json(), {"results":{
+            "is_applied"    :True,
+            "kakao_email"   :"pingping@gmail.com",
+            "kakao_nickname":"핑핑이",
+            "resumes"       :[
+                {
+                    "name"        :"이력서최종",
+                    "created_date":response.json()["results"]["resumes"][0]["created_date"],
+                    "uuid"        :"8b34d6f8-4a0f-4e77-9b50-22d562708fe5"
+                }
+            ]
+        }})
+
+    def test_fail_for_wrong_users_token_for_getting_user_data_about_job_position(self):
+        client   = Client()
+        token    = jwt.encode({"id":2, "exp":datetime.utcnow() + timedelta(days=2)}, SECRET_KEY, ALGORITHM)
+        headers  = {"HTTP_Authorization":token}
+        response = client.get("/jobs/1/user", **headers)
+
+        self.assertEqual(response.status_code, 400)
+        self.assertEqual(response.json(), {"message":"INVALID_USER"})
+
+    def test_success_for_getting_job_position_data(self):
+        client   = Client()
+        response = client.get("/jobs/1")
+
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.json(), {
+            "results": {
+                "job_position_id"       :1,
+                "job_categories_name"   :"Web Backend",
+                "due_date"              :"2022-04-02",
+                "title"                 :"개발자 구합니다",
+                "content"               :"4대보험 가능! 근로계약서 작성 노동청 앞에서 함!",
+                "company_name"          :"테슬라",
+                "company_location"      :"미국 텍사스",
+                "company_average_salary":"13500.00000",
+                "tags"                  :["#자율복장"],
+                "images"                :["https://raw.githubusercontent.com/wingna1/wantuPicbase/main/tesla1.jpg"]
+            }})
+
+    def test_fail_for_getting_non_existing_job_position_data(self):
+        client   = Client()
+        response = client.get("/jobs/100")
+
+        self.assertEqual(response.status_code, 400)
+        self.assertEqual(response.json(), {"message": "Data Does Not Exist"})
+
+    def test_success_for_getting_job_list_data_without_filter(self):
+        client   = Client()
+        response = client.get("/jobs")
+
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.json(), {
+            "results": {
+                "total_count":2,
+                "list_data":[
+                {
+                    "job_position_id" :1,
+                    "title"           :"개발자 구합니다",
+                    "company_name"    :"테슬라",
+                    "company_location":"미국 텍사스",
+                    "company_image"   :"https://raw.githubusercontent.com/wingna1/wantuPicbase/main/tesla1.jpg"
+                },
+                {
+                    "job_position_id" :2,
+                    "title"           :"개발자 환영! 대환영!",
+                    "company_name"    :"테슬라",
+                    "company_location":"미국 텍사스",
+                    "company_image"   :"https://raw.githubusercontent.com/wingna1/wantuPicbase/main/tesla1.jpg"
+                }
+            ]
+        }})
+
+    def test_success_for_getting_job_list_data_with_three_filters_one_sort_one_page(self):
+        client       = Client()
+        query_string = "?category=0&tag=0&area=미국&sort=id&offset=0&limit=1"
+        response     = client.get("/jobs" + query_string)
+
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.json(), {
+            "results":{
+                "total_count":2,
+                "list_data":[
+                {
+                    "job_position_id" :1,
+                    "title"           :"개발자 구합니다",
+                    "company_name"    :"테슬라",
+                    "company_location":"미국 텍사스",
+                    "company_image"   :"https://raw.githubusercontent.com/wingna1/wantuPicbase/main/tesla1.jpg"
+                }
+            ]
+        }})
+
+    def test_fail_for_getting_job_list_data_with_wrong_filter(self):
+        client       = Client()
+        query_string = "?category=100&tag=100&area=남극&sort=1"
+        response     = client.get("/jobs" + query_string)
+
+        self.assertEqual(response.status_code, 400)
+        self.assertEqual(response.json(), {"message":"Invalid Type of Parameter"})

--- a/jobs/urls.py
+++ b/jobs/urls.py
@@ -1,0 +1,9 @@
+from django.urls import path
+
+from jobs.views  import JobPositionDetailView, JobPositionListView, JobPositionUserDataView
+ 
+urlpatterns = [
+    path("/<int:job_position_id>", JobPositionDetailView.as_view()),
+    path("/<int:job_position_id>/user", JobPositionUserDataView.as_view()),
+    path("", JobPositionListView.as_view()),
+]

--- a/jobs/views.py
+++ b/jobs/views.py
@@ -1,3 +1,103 @@
-from django.shortcuts import render
+from django.http            import JsonResponse
+from django.db.models       import Q
+from django.views           import View
+from django.core.exceptions import FieldError
 
-# Create your views here.
+from applications.models    import Applicant, Application
+from jobs.models            import JobPosition
+from utils.login_decorator  import login_decorator
+
+class JobPositionUserDataView(View):
+    @login_decorator
+    def get(self, request, job_position_id):
+        user        = request.user
+        application = False
+
+        if Applicant.objects.filter(user_id=user.id):
+            application = Application.objects.filter(applicant_id=user.applicant_set.first().id, job_position_id=job_position_id)
+
+        is_applied = True if application else False
+        resumes    = [{
+                "name"        :resume.name,
+                "created_date":resume.created_at.strftime("%Y.%m.%d"),
+                "uuid"        :resume.uuid
+            } for resume in user.resume_set.all().filter(is_deleted=False)]
+
+        user_data = { 
+            "is_applied"    :is_applied,
+            "kakao_email"   :user.kakao_email,
+            "kakao_nickname":user.kakao_nickname,
+            "resumes"       :resumes
+        }
+        return JsonResponse({"results":user_data}, status=200)
+        
+class JobPositionDetailView(View):
+    def get(self, request, job_position_id):
+        try:
+            job_position = JobPosition.objects.get(id=job_position_id)
+
+            company = job_position.company
+
+            tag_list = job_position.tagnotification_set.all()
+            tags     = [ tag.tag.name for tag in tag_list ]
+
+            image_list = job_position.company.companyimage_set.all()
+            images     = [ image.image_url for image in image_list ]
+
+            data = {   
+                    "job_position_id"       :job_position.id,
+                    "job_categories_name"   :job_position.job_category.name,
+                    "due_date"              :job_position.due_date,
+                    "title"                 :job_position.title,
+                    "content"               :job_position.content,
+                    "company_name"          :company.name,
+                    "company_location"      :company.location,
+                    "company_average_salary":company.average_salary,
+                    "tags"                  :tags,
+                    "images"                :images
+            }
+            return JsonResponse({"results":data}, status=200)
+        except JobPosition.DoesNotExist:
+            return JsonResponse({"message":"Data Does Not Exist"}, status=400) 
+
+class JobPositionListView(View):
+    def get(self, request):
+        try:
+            tag_id      = int(request.GET.get("tag", 0))
+            category_id = int(request.GET.get("category", 0))
+            location    = request.GET.get("area")
+            sort        = request.GET.get("sort", "id")
+            offset      = int(request.GET.get("offset", 0))
+            limit       = int(request.GET.get("limit", 8))
+
+            q = Q()
+            if category_id != 0:
+                q &= Q(job_category_id=category_id)
+            if tag_id != 0:
+                q &= Q(tagnotification__tag_id=tag_id)    
+            if location:
+                q &= Q(company__location__startswith=location)
+            
+            requested_queryset = JobPosition.objects.select_related("company").filter(q).order_by(sort)
+            sliced_queryset    = requested_queryset[offset:limit]
+
+            list_data = [{
+                "job_position_id"  : data.id,
+                "title"            : data.title,
+                "company_name"     : data.company.name,
+                "company_location" : data.company.location,
+                "company_image"    : data.company.companyimage_set.first().image_url
+            } for data in sliced_queryset]
+
+            results = {
+                "total_count" : len(requested_queryset),
+                "list_data"   : list_data
+                }
+
+            return JsonResponse({"results":results}, status=200)
+        except KeyError:
+            return JsonResponse({"message":"Invalid Parameter"}, status=400) 
+        except ValueError:
+            return JsonResponse({"message":"Invalid Type of Parameter"}, status=400) 
+        except FieldError:
+            return JsonResponse({"message":"Invalid Type of Parameter"}, status=400) 

--- a/users/tests.py
+++ b/users/tests.py
@@ -39,7 +39,7 @@ class KakaoLoginTest(TestCase):
                 }
         mocked_requests.get = MagicMock(return_value = MockedResponse())
 
-        headers  = {"HTTP_access_token":"fakeTokenforTest"}
+        headers  = {"HTTP_Authorization":"fakeTokenforTest"}
         response = client.get("/users/kakao/login", **headers)
 
         response_token = response.json()["results"]["token"]
@@ -91,7 +91,7 @@ class KakaoLoginTest(TestCase):
                 }
         mocked_requests.get = MagicMock(return_value = MockedResponse())
         
-        headers  = {"HTTP_access_token":"fakeTokenforTest"}
+        headers  = {"HTTP_Authorization":"fakeTokenforTest"}
         response = client.get("/users/kakao/login", **headers)
 
         self.assertEqual(response.status_code, 400)
@@ -115,7 +115,7 @@ class KakaoLoginTest(TestCase):
                 }
         mocked_requests.get = MagicMock(return_value = MockedResponse())
         
-        headers  = {"HTTP_access_token":"fakeTokenforTest"}
+        headers  = {"HTTP_Authorization":"fakeTokenforTest"}
         response = client.get("/users/kakao/login", **headers)
 
         self.assertEqual(response.status_code, 400)
@@ -139,7 +139,7 @@ class KakaoLoginTest(TestCase):
                 }
         mocked_requests.get = MagicMock(return_value = MockedResponse())
 
-        headers  = {"HTTP_access_token":"fakeTokenforTest"}
+        headers  = {"HTTP_Authorization":"fakeTokenforTest"}
         response = client.get("/users/kakao/login", **headers)
 
         response_token = response.json()["results"]["token"]

--- a/wantu/settings.py
+++ b/wantu/settings.py
@@ -108,11 +108,11 @@ AUTH_PASSWORD_VALIDATORS = [
 
 LANGUAGE_CODE = 'en-us'
 
-TIME_ZONE = 'Asia/Seoul'
+TIME_ZONE = 'UTC'
 
 USE_I18N = True
 
-USE_TZ = False
+USE_TZ = True
 
 
 # Static files (CSS, JavaScript, Images)

--- a/wantu/urls.py
+++ b/wantu/urls.py
@@ -2,6 +2,7 @@ from django.urls import path, include
 
 urlpatterns = [
     path("users", include("users.urls")),
-    path('cv', include('cv.urls')),
-    path('applications', include('applications.urls'))
+    path('applications', include('applications.urls')),
+    path("jobs", include("jobs.urls")),
+    path('cv', include('cv.urls'))
 ]


### PR DESCRIPTION
…sts.py

## :: 최근 작업 주제 (하나 이상의 주제를 선택해주세요.)
- [x] 기능 추가
- [ ] 리뷰 반영
- [ ] 리팩토링
- [ ] 버그 수정
- [ ] 컨벤션 수정

<br />

## :: 구현 목표 (해당 브랜치에서 구현하고자 하는 하나의 목표를 설정합니다.)
- 채용 공고 리스트
- 채용 공고 상세 정보
- 채용 공고에 대한 유저 정보
- 위 api에 대한 테스트 케이스

<br />

## :: 구현 사항 설명 (작업한 내용을 상세하게 기록합니다.)
- 작업 중 프론트가 거의 완성되어 리스트와 상세 정보 api를 동시에 진행했습니다.

1. 채용 공고 리스트
- 페이징은 추가된다고 해서 주석이 남아있습니다.. 일단 다른 기능들을 리뷰받으려고 같이 PR 올립니다.
- Q객체 사용해 filter를 추가했습니다.

2. 채용 공고 상세 정보
- 패스 파라미터로 공고 id 받아 해당 공고에 대한 상세 정보 리턴
- tag와 image를 위해 각각 데이터 받으나 한 공고에 대한 데이터라 양이 적다

3. 채용 공고에 대한 유저 정보
- 사용자 id로 applicant에서 데이터를 찾아 해당 공고id에 대한 지원 내역을 찾아 boolean으로 리턴
- 지원하기 위한 이력서 리스트 리턴

4. 테스트 케이스 작성 완료
- created_at을 리턴하는 def test_success_for_getting_user_data_about_job_position()에서 날짜를 맞추는 법을 찾고 있습니다


<br />

## :: 성장 포인트 (해당 기능을 구현하며 고민했던 사항이나 새로 알게된 부분, 어려웠던 점 등을 작성합니다.)


<br />

## :: 기타 질문 및 특이 사항
- 리스트 api를 테스트할 때 카테고리 등 잘못된 파라미터가 전달될 경우 에러는 일어나지 않지만 빈 데이터가 리턴되는데 이 경우 def 이름을 test_success가 맞는지 fail이 맞는지 궁금합니다
